### PR TITLE
Ensure indices used in substring() are within length 

### DIFF
--- a/library/src/main/java/com/github/badoualy/datepicker/MonthView.java
+++ b/library/src/main/java/com/github/badoualy/datepicker/MonthView.java
@@ -325,12 +325,13 @@ public class MonthView extends RecyclerView {
             this.year = year;
             this.month = month;
 
-            String text = MONTHS[month].substring(0, 3).toUpperCase(Locale.US);
+            String text = MONTHS[month];
+            String truncatedText = text.substring(0, Math.min(text.length(), 3)).toUpperCase(Locale.US);
             if (yearDigitCount > 0) {
-                text += yearOnNewLine ? "\n" : " ";
-                text += year % (int) Math.pow(10, yearDigitCount);
+                truncatedText += yearOnNewLine ? "\n" : " ";
+                truncatedText += year % (int) Math.pow(10, yearDigitCount);
             }
-            lbl.setText(text);
+            lbl.setText(truncatedText);
             int color = selected ? colorSelected : beforeSelection ? colorBeforeSelection : defaultColor;
             lbl.setTextColor(color);
             indicator.setColor(color);

--- a/library/src/main/java/com/github/badoualy/datepicker/MonthView.java
+++ b/library/src/main/java/com/github/badoualy/datepicker/MonthView.java
@@ -326,12 +326,12 @@ public class MonthView extends RecyclerView {
             this.month = month;
 
             String text = MONTHS[month];
-            String truncatedText = text.substring(0, Math.min(text.length(), 3)).toUpperCase(Locale.US);
+            text = text.substring(0, Math.min(text.length(), 3)).toUpperCase(Locale.US);
             if (yearDigitCount > 0) {
-                truncatedText += yearOnNewLine ? "\n" : " ";
-                truncatedText += year % (int) Math.pow(10, yearDigitCount);
+                text += yearOnNewLine ? "\n" : " ";
+                text += year % (int) Math.pow(10, yearDigitCount);
             }
-            lbl.setText(truncatedText);
+            lbl.setText(text);
             int color = selected ? colorSelected : beforeSelection ? colorBeforeSelection : defaultColor;
             lbl.setTextColor(color);
             indicator.setColor(color);


### PR DESCRIPTION
Made in response to #20. This PR will safeguard indices being used in `substring()` calls not to exceed the string's own length.